### PR TITLE
Add core academic models and dashboard

### DIFF
--- a/academiques/admin.py
+++ b/academiques/admin.py
@@ -1,3 +1,46 @@
 from django.contrib import admin
+from import_export.admin import ImportExportModelAdmin
 
-# Register your models here.
+from .models import Classe, Eleve, Cours
+
+
+@admin.register(Classe)
+class ClasseAdmin(ImportExportModelAdmin):
+    list_display = ("nom", "cycle", "annee_scolaire", "ecole", "is_active", "created_at")
+    list_filter = ("cycle", "ecole", "annee_scolaire", "is_active")
+    search_fields = ("nom",)
+    readonly_fields = ("created_at", "last_update")
+
+    def save_model(self, request, obj, form, change):  # pragma: no cover - admin
+        if not change:
+            obj.create_by = request.user
+        obj.update_by = request.user
+        super().save_model(request, obj, form, change)
+
+
+@admin.register(Eleve)
+class EleveAdmin(ImportExportModelAdmin):
+    list_display = ("nom", "prenom", "genre", "classe", "ecole", "is_active", "created_at")
+    list_filter = ("genre", "classe", "ecole", "is_active")
+    search_fields = ("nom", "prenom")
+    readonly_fields = ("created_at", "last_update")
+
+    def save_model(self, request, obj, form, change):  # pragma: no cover - admin
+        if not change:
+            obj.create_by = request.user
+        obj.update_by = request.user
+        super().save_model(request, obj, form, change)
+
+
+@admin.register(Cours)
+class CoursAdmin(ImportExportModelAdmin):
+    list_display = ("nom", "classe", "ecole", "is_active", "created_at")
+    list_filter = ("classe", "ecole", "is_active")
+    search_fields = ("nom", "description")
+    readonly_fields = ("created_at", "last_update")
+
+    def save_model(self, request, obj, form, change):  # pragma: no cover - admin
+        if not change:
+            obj.create_by = request.user
+        obj.update_by = request.user
+        super().save_model(request, obj, form, change)

--- a/academiques/models.py
+++ b/academiques/models.py
@@ -1,3 +1,131 @@
 from django.db import models
+from django.conf import settings
 
-# Create your models here.
+from ecoles.models import Ecole, CycleEtude
+
+
+class Classe(models.Model):
+    nom = models.CharField(max_length=50)
+    cycle = models.ForeignKey(CycleEtude, on_delete=models.CASCADE)
+    ecole = models.ForeignKey(Ecole, on_delete=models.CASCADE)
+    annee_scolaire = models.CharField(max_length=9)
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    last_update = models.DateTimeField(auto_now=True)
+    is_active = models.BooleanField(default=True)
+    create_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="Classe_createby",
+    )
+    update_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="Classe_updateby",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return self.nom
+
+    """migrations code
+    operations = [
+        migrations.CreateModel(
+            name='Classe',
+            fields=[...],
+        )
+    ]
+    """
+
+
+class Eleve(models.Model):
+    GENRE_CHOICES = (
+        ("M", "Masculin"),
+        ("F", "Feminin"),
+    )
+
+    nom = models.CharField(max_length=100)
+    prenom = models.CharField(max_length=100)
+    genre = models.CharField(max_length=1, choices=GENRE_CHOICES)
+    date_naissance = models.DateField()
+    classe = models.ForeignKey(Classe, on_delete=models.CASCADE)
+    ecole = models.ForeignKey(Ecole, on_delete=models.CASCADE)
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    last_update = models.DateTimeField(auto_now=True)
+    is_active = models.BooleanField(default=True)
+    create_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="Eleve_createby",
+    )
+    update_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="Eleve_updateby",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.prenom} {self.nom}"
+
+    """migrations code
+    operations = [
+        migrations.CreateModel(
+            name='Eleve',
+            fields=[...],
+        )
+    ]
+    """
+
+
+class Cours(models.Model):
+    nom = models.CharField(max_length=100)
+    description = models.TextField(blank=True)
+    classe = models.ForeignKey(Classe, on_delete=models.CASCADE)
+    ecole = models.ForeignKey(Ecole, on_delete=models.CASCADE)
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    last_update = models.DateTimeField(auto_now=True)
+    is_active = models.BooleanField(default=True)
+    create_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="Cours_createby",
+    )
+    update_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="Cours_updateby",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return self.nom
+
+    """migrations code
+    operations = [
+        migrations.CreateModel(
+            name='Cours',
+            fields=[...],
+        )
+    ]
+    """

--- a/comptes/urls.py
+++ b/comptes/urls.py
@@ -9,4 +9,6 @@ urlpatterns = [
     path('', views.HomeView.as_view(), name='home'),
     path("login/", views.CustomLoginView.as_view(), name="login"),
     path("choisir-ecole/", views.ChoisirEcoleView.as_view(), name="choisir_ecole"),
+    path("dashboard/", views.DashboardView.as_view(), name="dashboard"),
+    path("dashboard/data/", views.DashboardDataView.as_view(), name="dashboard_data"),
 ]

--- a/ecoles/tests/test_ecole_mixin.py
+++ b/ecoles/tests/test_ecole_mixin.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from ecoles.models import Ecole
+from comptes.models import Profil
+
+User = get_user_model()
+
+class DashboardDataViewTest(TestCase):
+    def setUp(self):
+        self.ecole = Ecole.objects.create(
+            nom="Ecole Test",
+            slogan="",
+            description="",
+            adresse="Rue 1",
+            ville="Ville",
+            pays="Pays",
+            email_contact="a@a.com",
+            telephone_contact="000"
+        )
+        self.user = User.objects.create_user(username="u", password="p")
+        self.profil = Profil.objects.create(user=self.user, nom="u", matricule="M1")
+        self.profil.ecoles.add(self.ecole)
+        self.client.force_login(self.user)
+        session = self.client.session
+        session["ecole_id"] = self.ecole.id
+        session.save()
+
+    def test_dashboard_json_keys(self):
+        response = self.client.get("/comptes/dashboard/data/")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        for key in [
+            "effectif",
+            "n_classes",
+            "n_cours",
+            "total_encaisse",
+            "taux_presence",
+            "chart",
+            "timeline",
+        ]:
+            self.assertIn(key, data)

--- a/finance/admin.py
+++ b/finance/admin.py
@@ -1,3 +1,18 @@
 from django.contrib import admin
+from import_export.admin import ImportExportModelAdmin
 
-# Register your models here.
+from .models import Paiement
+
+
+@admin.register(Paiement)
+class PaiementAdmin(ImportExportModelAdmin):
+    list_display = ("eleve", "montant", "date_paiement", "ecole", "created_at")
+    list_filter = ("ecole", "date_paiement")
+    search_fields = ("eleve__nom", "eleve__prenom")
+    readonly_fields = ("created_at", "last_update")
+
+    def save_model(self, request, obj, form, change):  # pragma: no cover - admin
+        if not change:
+            obj.create_by = request.user
+        obj.update_by = request.user
+        super().save_model(request, obj, form, change)

--- a/finance/models.py
+++ b/finance/models.py
@@ -1,3 +1,44 @@
 from django.db import models
+from django.conf import settings
 
-# Create your models here.
+from ecoles.models import Ecole
+from academiques.models import Eleve
+
+
+class Paiement(models.Model):
+    eleve = models.ForeignKey(Eleve, on_delete=models.CASCADE)
+    montant = models.DecimalField(max_digits=10, decimal_places=2)
+    date_paiement = models.DateField()
+    ecole = models.ForeignKey(Ecole, on_delete=models.CASCADE)
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    last_update = models.DateTimeField(auto_now=True)
+    create_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="Paiement_createby",
+    )
+    update_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="Paiement_updateby",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.eleve} - {self.montant}"
+
+    """migrations code
+    operations = [
+        migrations.CreateModel(
+            name='Paiement',
+            fields=[...],
+        )
+    ]
+    """

--- a/presence/admin.py
+++ b/presence/admin.py
@@ -1,3 +1,18 @@
 from django.contrib import admin
+from import_export.admin import ImportExportModelAdmin
 
-# Register your models here.
+from .models import Presence
+
+
+@admin.register(Presence)
+class PresenceAdmin(ImportExportModelAdmin):
+    list_display = ("eleve", "date", "present", "ecole", "created_at")
+    list_filter = ("present", "ecole", "date")
+    search_fields = ("eleve__nom", "eleve__prenom")
+    readonly_fields = ("created_at", "last_update")
+
+    def save_model(self, request, obj, form, change):  # pragma: no cover - admin
+        if not change:
+            obj.create_by = request.user
+        obj.update_by = request.user
+        super().save_model(request, obj, form, change)

--- a/presence/models.py
+++ b/presence/models.py
@@ -1,3 +1,44 @@
 from django.db import models
+from django.conf import settings
 
-# Create your models here.
+from ecoles.models import Ecole
+from academiques.models import Eleve
+
+
+class Presence(models.Model):
+    eleve = models.ForeignKey(Eleve, on_delete=models.CASCADE)
+    date = models.DateField()
+    present = models.BooleanField(default=True)
+    ecole = models.ForeignKey(Ecole, on_delete=models.CASCADE)
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    last_update = models.DateTimeField(auto_now=True)
+    create_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="Presence_createby",
+    )
+    update_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="Presence_updateby",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.eleve} - {self.date}"
+
+    """migrations code
+    operations = [
+        migrations.CreateModel(
+            name='Presence',
+            fields=[...],
+        )
+    ]
+    """

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,0 +1,30 @@
+function kpiTemplate(icon, value, label) {
+  return '<div class="flex items-center"><i data-lucide="' + icon + '" class="mr-2"></i><div><div class="text-2xl font-bold">' + value + '</div><div class="text-sm">' + label + '</div></div></div>';
+}
+
+$(function () {
+  $.getJSON('/comptes/dashboard/data/', function (data) {
+    $('#kpi-effectif').html(kpiTemplate('users', data.effectif, 'Élèves'));
+    $('#kpi-classes').html(kpiTemplate('layers', data.n_classes, 'Classes'));
+    $('#kpi-cours').html(kpiTemplate('book', data.n_cours, 'Cours'));
+    $('#kpi-encaisse').html(kpiTemplate('credit-card', data.total_encaisse, 'Encaissements'));
+    $('#kpi-presence').html(kpiTemplate('check-circle', data.taux_presence + '%', 'Présence'));
+
+    new Chart(document.getElementById('chart-ca'), {
+      type: 'bar',
+      data: {
+        labels: data.chart.labels,
+        datasets: [{ label: 'Encaissements', data: data.chart.values }]
+      },
+      options: { responsive: true }
+    });
+
+    data.timeline.forEach(function (item) {
+      $('#timeline').append('<div>' + item + '</div>');
+    });
+
+    if (window.lucide) {
+      lucide.createIcons();
+    }
+  });
+});

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block content %}
+<div class="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+  <div id="kpi-effectif" class="p-4 border rounded"></div>
+  <div id="kpi-classes" class="p-4 border rounded"></div>
+  <div id="kpi-cours" class="p-4 border rounded"></div>
+  <div id="kpi-encaisse" class="p-4 border rounded"></div>
+  <div id="kpi-presence" class="p-4 border rounded"></div>
+</div>
+<div class="mb-6">
+  <canvas id="chart-ca"></canvas>
+</div>
+<div id="timeline" class="space-y-2"></div>
+{% endblock %}
+
+{% block javascript %}
+<script src="{% static 'js/dashboard.js' %}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement Classe, Eleve and Cours models
- implement Paiement and Presence models
- register new models in Django admin
- create dashboard template and JS logic
- expose dashboard views and URLs
- add tests for DashboardDataView JSON structure

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684da3de2cd08328beed49081c09e314